### PR TITLE
Fix case-insensitive email lookup for GitHub Copilot

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,7 @@ var knownAgentCommitters = map[string]string{
 	"209825114+claude[bot]@users.noreply.github.com":					"Claude",
 	"215619710+anthropic-claude[bot]@users.noreply.github.com":			"Claude (Anthropic)",
 	"208546643+claude-code-action[bot]@users.noreply.github.com": 		"Claude Code Action",
-	"198982749+Copilot@users.noreply.github.com": 						"GitHub Copilot (agent)",
+	"198982749+copilot@users.noreply.github.com": 						"GitHub Copilot (agent)",
 	"167198135+copilot[bot]@users.noreply.github.com": 					"GitHub Copilot (chat)",
 	"206951365+cursor[bot]@users.noreply.github.com": 					"Cursor",
 	"215057067+openai-codex[bot]@users.noreply.github.com": 			"OpenAI Codex",

--- a/utils_test.go
+++ b/utils_test.go
@@ -4,17 +4,61 @@ import (
     "testing"
 )
 
-func TestIdentifyAgentCommitterEmail(t *testing.T) {
-    name, exists := IdentifyAgentCommitterEmail("209825114+claude[bot]@users.noreply.github.com")
-    if name != "Claude" || exists != true {
-        t.Errorf(`IdentifyAgentCommitterEmail() for claude address = %q, %v, expecting %#q`, name, exists, "Claude")
+func TestIdentifyAgentCommitterEmailAllKnown(t *testing.T) {
+    for email, expectedName := range knownAgentCommitters {
+        name, exists := IdentifyAgentCommitterEmail(email)
+        if !exists || name != expectedName {
+            t.Errorf("IdentifyAgentCommitterEmail(%q) = %q, %v, want %q, true", email, name, exists, expectedName)
+        }
     }
 }
 
-func TestIdentifyAgentCommitterEmailNone(t *testing.T) {
-    name, exists := IdentifyAgentCommitterEmail("user@example.com")
-    if name != "" || exists != false {
-        t.Errorf(`IdentifyAgentCommitterEmail() for non agent address = %q, %v, expecting nothing to exist`, name, exists)
+func TestIdentifyAgentCommitterEmailMixedCase(t *testing.T) {
+    cases := []struct {
+        input    string
+        wantName string
+    }{
+        {"198982749+Copilot@users.noreply.github.com", "GitHub Copilot (agent)"},
+        {"209825114+CLAUDE[BOT]@USERS.NOREPLY.GITHUB.COM", "Claude"},
+        {"136622811+CodeRabbitAI[bot]@users.noreply.github.com", "CodeRabbit"},
+    }
+
+    for _, tc := range cases {
+        name, exists := IdentifyAgentCommitterEmail(tc.input)
+        if !exists || name != tc.wantName {
+            t.Errorf("IdentifyAgentCommitterEmail(%q) = %q, %v, want %q, true", tc.input, name, exists, tc.wantName)
+        }
     }
 }
 
+func TestIdentifyAgentCommitterEmailWhitespace(t *testing.T) {
+    cases := []string{
+        "  209825114+claude[bot]@users.noreply.github.com",
+        "209825114+claude[bot]@users.noreply.github.com  ",
+        "  209825114+claude[bot]@users.noreply.github.com  ",
+    }
+
+    for _, email := range cases {
+        name, exists := IdentifyAgentCommitterEmail(email)
+        if !exists || name != "Claude" {
+            t.Errorf("IdentifyAgentCommitterEmail(%q) = %q, %v, want %q, true", email, name, exists, "Claude")
+        }
+    }
+}
+
+func TestIdentifyAgentCommitterEmailNotFound(t *testing.T) {
+    cases := []string{
+        "user@example.com",
+        "",
+        "  ",
+        "claude@anthropic.com",
+        "not-a-bot@users.noreply.github.com",
+    }
+
+    for _, email := range cases {
+        name, exists := IdentifyAgentCommitterEmail(email)
+        if exists || name != "" {
+            t.Errorf("IdentifyAgentCommitterEmail(%q) = %q, %v, want \"\", false", email, name, exists)
+        }
+    }
+}


### PR DESCRIPTION
The Copilot agent email key had a capital C (`198982749+Copilot@...`) but `IdentifyAgentCommitterEmail` lowercases input before doing the map lookup, so it could never match. Lowercased the key and added a test for mixed-case input.