### PR TITLE
Detect EntireIO trailers in commit messages

### DIFF
--- a/detection/message/message.go
+++ b/detection/message/message.go
@@ -23,6 +23,27 @@ var commitMessagePatterns = []struct {
 		},
 		name: "Claude Code",
 	},
+	{
+		check: func(msg string) bool {
+			trailers := []string{
+				"Entire-Metadata",
+				"Entire-Metadata-Task",
+				"Entire-Strategy",
+				"Entire-Session",
+				"Entire-Condensation",
+				"Entire-Source-Ref",
+				"Entire-Checkpoint",
+				"Entire-Agent",
+			}
+			for _, trailer := range trailers {
+				if strings.Contains(msg, fmt.Sprintf("\n%s:", trailer)) {
+					return true
+				}
+			}
+			return false
+		},
+		name: "EntireIO",
+	},
 }
 
 type Detector struct{}

--- a/detection/message/message_test.go
+++ b/detection/message/message_test.go
@@ -34,6 +34,26 @@ func TestDetect(t *testing.T) {
 			wantTools: []string{"Claude Code"},
 		},
 		{
+			name:      "EntireIO trailer present in commit",
+			message:   "this is some commit message\n\nEntire-Checkpoint: ab123cdefg12",
+			wantTools: []string{"EntireIO"},
+		},
+		{
+			name:      "Another EntireIO trailer present in commit",
+			message:   "this is some commit message\n\nEntire-Metadata: ab123cdefg12",
+			wantTools: []string{"EntireIO"},
+		},
+		{
+			name:      "Another EntireIO trailer present in commit with CRLF line endings",
+			message:   "this is some commit message\r\n\r\nEntire-Metadata: ab123cdefg12",
+			wantTools: []string{"EntireIO"},
+		},
+		{
+			name:      "EntireIO trailer not used, only mentioned in a commit",
+			message:   "this is a commit message with\nEntire-Metadata mentioned",
+			wantTools: nil,
+		},
+		{
 			name:      "no patterns",
 			message:   "normal commit message with no AI signatures",
 			wantTools: nil,


### PR DESCRIPTION
Closes https://github.com/chaoss/ai-detection-action/issues/21

Changes:
- functionality to detect EntireIO specific trailers in commit messages
- corresponding test cases