### PR TITLE
Swap Augur with the community-led CollectOSS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A standalone CLI tool and GitHub Action that detects AI-generated contributions in git repositories. It works entirely from git-level data (commit emails, messages, trailers) using [go-git](https://github.com/go-git/go-git), with no platform API dependencies in the core. A separate text-scanning mode lets wrappers pipe in PR descriptions, issue comments, or any other text.
 
-The goal is to help open source maintainers understand when AI tools are involved in contributions, and to give community health projects like [Augur](https://github.com/chaoss/augur/) and [GrimoireLab](https://github.com/chaoss/grimoirelab/) a way to track AI usage across repositories.
+The goal is to help open source maintainers understand when AI tools are involved in contributions, and to give community health projects like [CollectOSS](https://github.com/chaoss/collectoss/) and [GrimoireLab](https://github.com/chaoss/grimoirelab/) a way to track AI usage across repositories.
 
 ## What it detects
 


### PR DESCRIPTION
Augur is no longer part of CHAOSS, so swap the reference in the README to CollectOSS (the community led fork) 