### PR TITLE
Update cli and package name to disclosure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 This project is still in its early stages.
 
-The best way to get involved is to join the [CHAOSS Slack](https://chaoss.community/kb-getting-started/) in the #data-ai-detection-action channel to be part of the conversation.
+The best way to get involved is to join the [CHAOSS Slack](https://chaoss.community/kb-getting-started/) in the #data-ai-disclosure-detection channel to be part of the conversation.
 
 We hope to start better documenting our planned tasks, enforcing a pull request based workflow (potentially with DCO signoff) and creating more documentation in the near future

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Four detectors run against each commit, each producing findings at a confidence 
 ## CLI usage
 
 ```
-ai-detection scan [--range=BASE..HEAD] [--format=json|text] [--min-confidence=low|medium|high] [repo-path]
-ai-detection text [--format=json|text] [--input=FILE|-]
-ai-detection version
+disclosure scan [--range=BASE..HEAD] [--format=json|text] [--min-confidence=low|medium|high] [repo-path]
+disclosure text [--format=json|text] [--input=FILE|-]
+disclosure version
 ```
 
 Exit codes: `0` = no AI detected, `1` = AI detected, `2` = error.
@@ -36,13 +36,13 @@ Exit codes: `0` = no AI detected, `1` = AI detected, `2` = error.
 
 ```sh
 # Scan all commits in the current repo
-ai-detection scan
+disclosure scan
 
 # Scan a specific range, JSON output
-ai-detection scan --range=abc123..def456 --format=json
+disclosure scan --range=abc123..def456 --format=json
 
 # Only report high-confidence findings
-ai-detection scan --min-confidence=high /path/to/repo
+disclosure scan --min-confidence=high /path/to/repo
 ```
 
 ### Scan text
@@ -50,9 +50,9 @@ ai-detection scan --min-confidence=high /path/to/repo
 Reads from stdin by default, or from a file with `--input`:
 
 ```sh
-echo "I used Claude to write this PR" | ai-detection text --format=json
+echo "I used Claude to write this PR" | disclosure text --format=json
 
-ai-detection text --input=pr-body.txt
+disclosure text --input=pr-body.txt
 ```
 
 ### Use as a CI gate
@@ -60,7 +60,7 @@ ai-detection text --input=pr-body.txt
 The exit code makes it usable in shell pipelines and CI scripts:
 
 ```sh
-if ai-detection scan --range=$BASE..$HEAD --min-confidence=medium; then
+if disclosure scan --range=$BASE..$HEAD --min-confidence=medium; then
   echo "No AI detected"
 else
   echo "AI involvement detected"
@@ -72,7 +72,7 @@ fi
 Add to your workflow to automatically label PRs with detected AI involvement:
 
 ```yaml
-- uses: chaoss/ai-detection-action/action@main
+- uses: chaoss/disclosure/action@main
   with:
     label: 'ai-detected'        # label to apply (default: ai-detected)
     min-confidence: 'low'        # low, medium, or high (default: low)
@@ -91,7 +91,7 @@ The labeling logic lives entirely in the action layer. The CLI reports findings;
 The detection packages can be imported directly into other Go projects:
 
 ```sh
-go get github.com/chaoss/ai-detection-action
+go get github.com/chaoss/disclosure
 ```
 
 Scan a repo's commits with the built-in detectors:
@@ -102,12 +102,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/detection/coauthor"
-	"github.com/chaoss/ai-detection-action/detection/committer"
-	"github.com/chaoss/ai-detection-action/detection/message"
-	"github.com/chaoss/ai-detection-action/detection/toolmention"
-	"github.com/chaoss/ai-detection-action/scan"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/detection/coauthor"
+	"github.com/chaoss/disclosure/detection/committer"
+	"github.com/chaoss/disclosure/detection/message"
+	"github.com/chaoss/disclosure/detection/toolmention"
+	"github.com/chaoss/disclosure/scan"
 )
 
 func main() {
@@ -152,7 +152,7 @@ Pass it alongside the built-in detectors and the scan functions will run it the 
 ## Building from source
 
 ```sh
-go build -o ai-detection .
+go build -o disclosure .
 ```
 
 Requires Go 1.24+.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,14 +5,14 @@ import (
 	"io"
 	"os"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/detection/coauthor"
-	"github.com/chaoss/ai-detection-action/detection/committer"
-	"github.com/chaoss/ai-detection-action/detection/gitnotes"
-	"github.com/chaoss/ai-detection-action/detection/message"
-	"github.com/chaoss/ai-detection-action/detection/toolmention"
-	"github.com/chaoss/ai-detection-action/output"
-	"github.com/chaoss/ai-detection-action/scan"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/detection/coauthor"
+	"github.com/chaoss/disclosure/detection/committer"
+	"github.com/chaoss/disclosure/detection/gitnotes"
+	"github.com/chaoss/disclosure/detection/message"
+	"github.com/chaoss/disclosure/detection/toolmention"
+	"github.com/chaoss/disclosure/output"
+	"github.com/chaoss/disclosure/scan"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func allDetectors() []detection.Detector {
 // Run is the main entry point for the CLI. Returns an exit code.
 func Run(args []string, stdout, stderr io.Writer) int {
 	rootCmd := &cobra.Command{
-		Use:           "ai-detection",
+		Use:           "disclosure",
 		Short:         "Detect AI-generated contributions",
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -190,7 +190,7 @@ func versionCommand(stdout io.Writer, exitCode *int) *cobra.Command {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Fprintf(stdout, "ai-detection %s\n", Version)
+			fmt.Fprintf(stdout, "disclosure %s\n", Version)
 			*exitCode = ExitNoAI
 		},
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/scan"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/scan"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
@@ -72,7 +72,7 @@ func TestRunNoArgs(t *testing.T) {
 	if code != ExitNoAI {
 		t.Errorf("exit code = %d, want %d", code, ExitNoAI)
 	}
-	if !strings.Contains(stdout.String(), "ai-detection") {
+	if !strings.Contains(stdout.String(), "disclosure") {
 		t.Errorf("expected help output, got: %s", stdout.String())
 	}
 }
@@ -91,7 +91,7 @@ func TestRunVersion(t *testing.T) {
 	if code != ExitNoAI {
 		t.Errorf("exit code = %d, want %d", code, ExitNoAI)
 	}
-	if !strings.Contains(stdout.String(), "ai-detection") {
+	if !strings.Contains(stdout.String(), "disclosure") {
 		t.Errorf("expected version output, got: %s", stdout.String())
 	}
 }

--- a/detection/coauthor/coauthor.go
+++ b/detection/coauthor/coauthor.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 var knownCoAuthorEmails = map[string]string{

--- a/detection/coauthor/coauthor_test.go
+++ b/detection/coauthor/coauthor_test.go
@@ -3,7 +3,7 @@ package coauthor
 import (
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 func TestDetect(t *testing.T) {

--- a/detection/committer/committer.go
+++ b/detection/committer/committer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 // knownAgentCommitters maps GitHub noreply emails to AI tool names.

--- a/detection/committer/committer_test.go
+++ b/detection/committer/committer_test.go
@@ -3,7 +3,7 @@ package committer
 import (
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 func TestDetectAllKnownEmails(t *testing.T) {

--- a/detection/gitnotes/gitnotes.go
+++ b/detection/gitnotes/gitnotes.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 // metadata represents the JSON metadata section of a git-ai authorship log.

--- a/detection/gitnotes/gitnotes_test.go
+++ b/detection/gitnotes/gitnotes_test.go
@@ -3,7 +3,7 @@ package gitnotes
 import (
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 func TestDetect(t *testing.T) {

--- a/detection/message/message.go
+++ b/detection/message/message.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 var commitMessagePatterns = []struct {

--- a/detection/message/message_test.go
+++ b/detection/message/message_test.go
@@ -3,7 +3,7 @@ package message
 import (
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 func TestDetect(t *testing.T) {

--- a/detection/toolmention/toolmention.go
+++ b/detection/toolmention/toolmention.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 // toolPatterns maps AI tool names to compiled word-boundary regexes.

--- a/detection/toolmention/toolmention_test.go
+++ b/detection/toolmention/toolmention_test.go
@@ -3,7 +3,7 @@ package toolmention
 import (
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
+	"github.com/chaoss/disclosure/detection"
 )
 
 func TestDetect(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chaoss/ai-detection-action
+module github.com/chaoss/disclosure
 
 go 1.24.0
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"github.com/chaoss/ai-detection-action/cmd"
+	"github.com/chaoss/disclosure/cmd"
 )
 
 func main() {

--- a/output/output.go
+++ b/output/output.go
@@ -7,8 +7,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/scan"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/scan"
 )
 
 // FormatJSON writes the report as JSON to w.

--- a/output/output_test.go
+++ b/output/output_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/scan"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/scan"
 )
 
 func sampleReport() scan.Report {

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -1,8 +1,8 @@
 package scan
 
 import (
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/gitops"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/gitops"
 )
 
 // CommitResult holds findings for a single commit.

--- a/scan/scan_test.go
+++ b/scan/scan_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chaoss/ai-detection-action/detection"
-	"github.com/chaoss/ai-detection-action/detection/coauthor"
-	"github.com/chaoss/ai-detection-action/detection/committer"
-	"github.com/chaoss/ai-detection-action/detection/gitnotes"
-	"github.com/chaoss/ai-detection-action/detection/message"
-	"github.com/chaoss/ai-detection-action/detection/toolmention"
+	"github.com/chaoss/disclosure/detection"
+	"github.com/chaoss/disclosure/detection/coauthor"
+	"github.com/chaoss/disclosure/detection/committer"
+	"github.com/chaoss/disclosure/detection/gitnotes"
+	"github.com/chaoss/disclosure/detection/message"
+	"github.com/chaoss/disclosure/detection/toolmention"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )


### PR DESCRIPTION
Closes #34.

This PR updates the cli command and package name to `disclosure`, in accordance with the repo name change to `github.com/chaoss/disclosure`.

Additionally it also fixes the slack channel name to `#data-ai-disclosure-detection` in readme.