### PR TITLE
feat: detect t3.chat tool mentions

### DIFF
--- a/detection/toolmention/toolmention.go
+++ b/detection/toolmention/toolmention.go
@@ -35,6 +35,7 @@ func init() {
 		"JetBrains AI",
 		"CodeRabbit",
 		"ChatGPT",
+		"t3.chat",
 		"GPT-4",
 		"Windsurf",
 	}

--- a/detection/toolmention/toolmention_test.go
+++ b/detection/toolmention/toolmention_test.go
@@ -70,6 +70,21 @@ func TestDetect(t *testing.T) {
 			wantTools: []string{"ChatGPT"},
 		},
 		{
+			name:      "t3.chat mention",
+			input:     detection.Input{Text: "I used t3.chat to compare model outputs"},
+			wantTools: []string{"t3.chat"},
+		},
+		{
+			name:      "t3.chat mention is case insensitive",
+			input:     detection.Input{Text: "Generated with T3.CHAT"},
+			wantTools: []string{"t3.chat"},
+		},
+		{
+			name:      "t3.chat word boundary prevents partial match",
+			input:     detection.Input{Text: "This mentions t3.chatty, not the tool"},
+			wantTools: nil,
+		},
+		{
 			name:      "Windsurf mention",
 			input:     detection.Input{Text: "Written with Windsurf IDE"},
 			wantTools: []string{"Windsurf"},


### PR DESCRIPTION
closes #31 

## Summary

Adds `t3.chat` to the list of casual AI tool mentions detected in text and commit messages.

## Changes

- Adds `t3.chat` to the tool mention detector.
- Adds test coverage for:
  - normal `t3.chat` mentions
  - case-insensitive matching
  - avoiding partial matches like `t3.chatty`

## Testing

- `go test ./detection/toolmention`
- `go test ./...`
- `git diff --check`