### PR TITLE
Add workflow to run ai detection action within repo

### DIFF
--- a/.github/workflows/ai_detection.yml
+++ b/.github/workflows/ai_detection.yml
@@ -1,0 +1,25 @@
+# Workflow to run our AI Detection action
+# https://github.com/chaoss/disclosure/blob/main/action/action.yml
+
+name: Run AI Detection action locally in repo
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  # pr and issue write access is needed by the ai detection action
+  # to add a label to the pr, in this step:
+  # https://github.com/chaoss/disclosure/blob/main/action/action.yml#L95-L99
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-ai-detection-action:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Run AI detection action
+      uses: ./action

--- a/.github/workflows/ai_detection.yml
+++ b/.github/workflows/ai_detection.yml
@@ -21,5 +21,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        # we get commit history from base as its needed by the AI detection action
+        fetch-depth: 0
     - name: Run AI detection action
       uses: ./action


### PR DESCRIPTION
Closes #14.

This PR adds a gh workflow to run our AI detection action locally within repo.

Also please note, while looking into this I found a permissions concern, have created a separate issue #40 for it.