### PR TITLE
feat: enable self-detection of actions config via CLI

### DIFF
--- a/cmd/actions.go
+++ b/cmd/actions.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/chaoss/disclosure/workflow"
+	"github.com/spf13/cobra"
+)
+
+func actionsCommand(stdout, stderr io.Writer, exitCode *int) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "actions [repo-path]",
+		Short: "Detect configured AI labels from GitHub Actions workflows",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			repoPath := "."
+			if len(args) > 0 {
+				repoPath = args[0]
+			}
+
+			config, err := workflow.DetectLabels(repoPath)
+			if err != nil {
+				fmt.Fprintf(stderr, "error reading workflows: %v\n", err)
+				*exitCode = ExitError
+				return err
+			}
+
+			enc := json.NewEncoder(stdout)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(config); err != nil {
+				fmt.Fprintf(stderr, "error formatting json: %v\n", err)
+				*exitCode = ExitError
+				return err
+			}
+
+			return nil
+		},
+	}
+	return cmd
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,6 +65,7 @@ Exit codes:
 
 	rootCmd.AddCommand(scanCommand(stdout, stderr, &exitCode))
 	rootCmd.AddCommand(textCommand(stdout, stderr, &exitCode))
+	rootCmd.AddCommand(actionsCommand(stdout, stderr, &exitCode))
 	rootCmd.AddCommand(versionCommand(stdout, &exitCode))
 	rootCmd.AddCommand(generateDocs(&exitCode))
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -65,7 +65,7 @@ Exit codes:
 
 	rootCmd.AddCommand(scanCommand(stdout, stderr, &exitCode))
 	rootCmd.AddCommand(textCommand(stdout, stderr, &exitCode))
-	rootCmd.AddCommand(actionsCommand(stdout, stderr, &exitCode))
+	rootCmd.AddCommand(findConfigCommand(stdout, stderr, &exitCode))
 	rootCmd.AddCommand(versionCommand(stdout, &exitCode))
 	rootCmd.AddCommand(generateDocs(&exitCode))
 

--- a/cmd/find_config.go
+++ b/cmd/find_config.go
@@ -9,10 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func actionsCommand(stdout, stderr io.Writer, exitCode *int) *cobra.Command {
+func findConfigCommand(stdout, stderr io.Writer, exitCode *int) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "actions [repo-path]",
-		Short: "Detect configured AI labels from GitHub Actions workflows",
+		Use:   "find-config [repo-path]",
+		Short: "Detect configured AI settings from GitHub Actions workflows",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			repoPath := "."
@@ -20,7 +20,7 @@ func actionsCommand(stdout, stderr io.Writer, exitCode *int) *cobra.Command {
 				repoPath = args[0]
 			}
 
-			config, err := workflow.DetectLabels(repoPath)
+			config, err := workflow.DetectConfigs(repoPath)
 			if err != nil {
 				fmt.Fprintf(stderr, "error reading workflows: %v\n", err)
 				*exitCode = ExitError

--- a/cmd/find_config.go
+++ b/cmd/find_config.go
@@ -22,16 +22,20 @@ func findConfigCommand(stdout, stderr io.Writer, exitCode *int) *cobra.Command {
 
 			config, err := workflow.DetectConfigs(repoPath)
 			if err != nil {
-				fmt.Fprintf(stderr, "error reading workflows: %v\n", err)
 				*exitCode = ExitError
+				if _, writeErr := fmt.Fprintf(stderr, "error reading workflows: %v\n", err); writeErr != nil {
+					return writeErr
+				}
 				return err
 			}
 
 			enc := json.NewEncoder(stdout)
 			enc.SetIndent("", "  ")
 			if err := enc.Encode(config); err != nil {
-				fmt.Fprintf(stderr, "error formatting json: %v\n", err)
 				*exitCode = ExitError
+				if _, writeErr := fmt.Fprintf(stderr, "error formatting json: %v\n", err); writeErr != nil {
+					return writeErr
+				}
 				return err
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/text v0.40.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -34,5 +35,4 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,5 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,0 +1,88 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Workflow struct {
+	Jobs map[string]Job `yaml:"jobs"`
+}
+
+type Job struct {
+	Steps []Step `yaml:"steps"`
+}
+
+type Step struct {
+	Uses string            `yaml:"uses"`
+	With map[string]string `yaml:"with"`
+}
+
+// Config represents the extracted AI labels from workflow files.
+type Config struct {
+	Labels []string `json:"labels"`
+}
+
+// DetectLabels scans the .github/workflows directory for the chaoss/disclosure action
+// and returns all configured labels. If the action is found but no label is specified,
+// it returns the default "ai-detected".
+func DetectLabels(repoPath string) (*Config, error) {
+	workflowsDir := filepath.Join(repoPath, ".github", "workflows")
+	entries, err := os.ReadDir(workflowsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{Labels: []string{}}, nil
+		}
+		return nil, err
+	}
+
+	seenLabels := make(map[string]bool)
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(entry.Name()))
+		if ext != ".yml" && ext != ".yaml" {
+			continue
+		}
+
+		path := filepath.Join(workflowsDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		var wf Workflow
+		if err := yaml.Unmarshal(data, &wf); err != nil {
+			continue
+		}
+
+		for _, job := range wf.Jobs {
+			for _, step := range job.Steps {
+				uses := strings.TrimSpace(step.Uses)
+				if strings.HasPrefix(uses, "chaoss/disclosure@") || uses == "chaoss/disclosure" {
+					label := step.With["label"]
+					if label == "" {
+						label = "ai-detected"
+					}
+					seenLabels[label] = true
+				}
+			}
+		}
+	}
+
+	var labels []string
+	for l := range seenLabels {
+		labels = append(labels, l)
+	}
+
+	if labels == nil {
+		labels = []string{} // return empty slice rather than null in json
+	}
+
+	return &Config{Labels: labels}, nil
+}

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,29 +18,42 @@ type Job struct {
 }
 
 type Step struct {
-	Uses string            `yaml:"uses"`
-	With map[string]string `yaml:"with"`
+	Uses string                 `yaml:"uses"`
+	With map[string]interface{} `yaml:"with"`
 }
 
-// Config represents the extracted AI labels from workflow files.
+// ActionConfig represents the extracted configuration for a single use of the action.
+type ActionConfig struct {
+	Label         string `json:"label"`
+	MinConfidence string `json:"min_confidence"`
+	ScanPRBody    string `json:"scan_pr_body"`
+}
+
+// Config represents the extracted AI configurations from workflow files.
 type Config struct {
-	Labels []string `json:"labels"`
+	Configs []ActionConfig `json:"configs"`
 }
 
-// DetectLabels scans the .github/workflows directory for the chaoss/disclosure action
-// and returns all configured labels. If the action is found but no label is specified,
-// it returns the default "ai-detected".
-func DetectLabels(repoPath string) (*Config, error) {
+func getString(m map[string]interface{}, key, def string) string {
+	if v, ok := m[key]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return def
+}
+
+// DetectConfigs scans the .github/workflows directory for the chaoss/disclosure action
+// and returns all configured instances. Default values are populated for missing inputs.
+func DetectConfigs(repoPath string) (*Config, error) {
 	workflowsDir := filepath.Join(repoPath, ".github", "workflows")
 	entries, err := os.ReadDir(workflowsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &Config{Labels: []string{}}, nil
+			return &Config{Configs: []ActionConfig{}}, nil
 		}
 		return nil, err
 	}
 
-	seenLabels := make(map[string]bool)
+	seenConfigs := make(map[ActionConfig]bool)
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -65,24 +79,25 @@ func DetectLabels(repoPath string) (*Config, error) {
 			for _, step := range job.Steps {
 				uses := strings.TrimSpace(step.Uses)
 				if strings.HasPrefix(uses, "chaoss/disclosure@") || uses == "chaoss/disclosure" {
-					label := step.With["label"]
-					if label == "" {
-						label = "ai-detected"
+					ac := ActionConfig{
+						Label:         getString(step.With, "label", "ai-detected"),
+						MinConfidence: getString(step.With, "min-confidence", "low"),
+						ScanPRBody:    getString(step.With, "scan-pr-body", "true"),
 					}
-					seenLabels[label] = true
+					seenConfigs[ac] = true
 				}
 			}
 		}
 	}
 
-	var labels []string
-	for l := range seenLabels {
-		labels = append(labels, l)
+	var configs []ActionConfig
+	for c := range seenConfigs {
+		configs = append(configs, c)
 	}
 
-	if labels == nil {
-		labels = []string{} // return empty slice rather than null in json
+	if configs == nil {
+		configs = []ActionConfig{}
 	}
 
-	return &Config{Labels: labels}, nil
+	return &Config{Configs: configs}, nil
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -36,11 +36,18 @@ type Config struct {
 	Configs []ActionConfig `json:"configs"`
 }
 
+const disclosureActionUse = "chaoss/disclosure/action"
+
 func getString(m map[string]interface{}, key, def string) string {
 	if v, ok := m[key]; ok {
 		return fmt.Sprintf("%v", v)
 	}
 	return def
+}
+
+func isDisclosureActionUse(uses string) bool {
+	uses = strings.TrimSpace(uses)
+	return uses == disclosureActionUse || strings.HasPrefix(uses, disclosureActionUse+"@")
 }
 
 // DetectConfigs scans the .github/workflows directory for the chaoss/disclosure action
@@ -80,8 +87,7 @@ func DetectConfigs(repoPath string) (*Config, error) {
 
 		for _, job := range wf.Jobs {
 			for _, step := range job.Steps {
-				uses := strings.TrimSpace(step.Uses)
-				if strings.HasPrefix(uses, "chaoss/disclosure@") || uses == "chaoss/disclosure" {
+				if isDisclosureActionUse(step.Uses) {
 					ac := ActionConfig{
 						Label:           getString(step.With, "label", "ai-detected"),
 						LabelingEnabled: getString(step.With, "labeling-enabled", "false"),

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -24,9 +25,10 @@ type Step struct {
 
 // ActionConfig represents the extracted configuration for a single use of the action.
 type ActionConfig struct {
-	Label         string `json:"label"`
-	MinConfidence string `json:"min_confidence"`
-	ScanPRBody    string `json:"scan_pr_body"`
+	Label           string `json:"label"`
+	LabelingEnabled string `json:"labeling_enabled"`
+	MinConfidence   string `json:"min_confidence"`
+	ScanPRBody      string `json:"scan_pr_body"`
 }
 
 // Config represents the extracted AI configurations from workflow files.
@@ -54,6 +56,7 @@ func DetectConfigs(repoPath string) (*Config, error) {
 	}
 
 	seenConfigs := make(map[ActionConfig]bool)
+	configs := []ActionConfig{}
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -80,24 +83,33 @@ func DetectConfigs(repoPath string) (*Config, error) {
 				uses := strings.TrimSpace(step.Uses)
 				if strings.HasPrefix(uses, "chaoss/disclosure@") || uses == "chaoss/disclosure" {
 					ac := ActionConfig{
-						Label:         getString(step.With, "label", "ai-detected"),
-						MinConfidence: getString(step.With, "min-confidence", "low"),
-						ScanPRBody:    getString(step.With, "scan-pr-body", "true"),
+						Label:           getString(step.With, "label", "ai-detected"),
+						LabelingEnabled: getString(step.With, "labeling-enabled", "false"),
+						MinConfidence:   getString(step.With, "min-confidence", "low"),
+						ScanPRBody:      getString(step.With, "scan-pr-body", "true"),
+					}
+					if seenConfigs[ac] {
+						continue
 					}
 					seenConfigs[ac] = true
+					configs = append(configs, ac)
 				}
 			}
 		}
 	}
 
-	var configs []ActionConfig
-	for c := range seenConfigs {
-		configs = append(configs, c)
-	}
-
-	if configs == nil {
-		configs = []ActionConfig{}
-	}
+	sort.Slice(configs, func(i, j int) bool {
+		if configs[i].Label != configs[j].Label {
+			return configs[i].Label < configs[j].Label
+		}
+		if configs[i].LabelingEnabled != configs[j].LabelingEnabled {
+			return configs[i].LabelingEnabled < configs[j].LabelingEnabled
+		}
+		if configs[i].MinConfidence != configs[j].MinConfidence {
+			return configs[i].MinConfidence < configs[j].MinConfidence
+		}
+		return configs[i].ScanPRBody < configs[j].ScanPRBody
+	})
 
 	return &Config{Configs: configs}, nil
 }

--- a/workflow/workflow.go
+++ b/workflow/workflow.go
@@ -25,29 +25,121 @@ type Step struct {
 
 // ActionConfig represents the extracted configuration for a single use of the action.
 type ActionConfig struct {
-	Label           string `json:"label"`
-	LabelingEnabled string `json:"labeling_enabled"`
-	MinConfidence   string `json:"min_confidence"`
-	ScanPRBody      string `json:"scan_pr_body"`
+	SourceFile      string   `json:"source_file"`
+	ActionRef       string   `json:"action_ref"`
+	Label           string   `json:"label"`
+	LabelingEnabled string   `json:"labeling_enabled"`
+	MinConfidence   string   `json:"min_confidence"`
+	ScanPRBody      string   `json:"scan_pr_body"`
+	ExplicitInputs  []string `json:"explicit_inputs"`
+	DefaultedInputs []string `json:"defaulted_inputs"`
 }
 
 // Config represents the extracted AI configurations from workflow files.
 type Config struct {
-	Configs []ActionConfig `json:"configs"`
+	Configs    []ActionConfig `json:"configs"`
+	Warnings   []Warning      `json:"warnings,omitempty"`
+	Incomplete bool           `json:"incomplete"`
+}
+
+// Warning represents a recoverable workflow parsing or read problem.
+type Warning struct {
+	SourceFile string `json:"source_file"`
+	Error      string `json:"error"`
 }
 
 const disclosureActionUse = "chaoss/disclosure/action"
 
-func getString(m map[string]interface{}, key, def string) string {
-	if v, ok := m[key]; ok {
-		return fmt.Sprintf("%v", v)
-	}
-	return def
+var actionInputDefaults = map[string]string{
+	"label":            "ai-detected",
+	"labeling-enabled": "false",
+	"min-confidence":   "low",
+	"scan-pr-body":     "true",
 }
 
-func isDisclosureActionUse(uses string) bool {
+func actionRef(uses string) (string, bool) {
 	uses = strings.TrimSpace(uses)
-	return uses == disclosureActionUse || strings.HasPrefix(uses, disclosureActionUse+"@")
+	if uses == disclosureActionUse {
+		return "", true
+	}
+	if strings.HasPrefix(uses, disclosureActionUse+"@") {
+		return strings.TrimPrefix(uses, disclosureActionUse+"@"), true
+	}
+	return "", false
+}
+
+func getInput(m map[string]interface{}, key string) (string, bool) {
+	if v, ok := m[key]; ok {
+		return fmt.Sprintf("%v", v), true
+	}
+	return actionInputDefaults[key], false
+}
+
+func actionConfig(sourceFile, ref string, with map[string]interface{}) ActionConfig {
+	explicitInputs := []string{}
+	defaultedInputs := []string{}
+	values := map[string]string{}
+
+	inputKeys := []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"}
+	for _, key := range inputKeys {
+		value, explicit := getInput(with, key)
+		values[key] = value
+		if explicit {
+			explicitInputs = append(explicitInputs, key)
+		} else {
+			defaultedInputs = append(defaultedInputs, key)
+		}
+	}
+
+	return ActionConfig{
+		SourceFile:      sourceFile,
+		ActionRef:       ref,
+		Label:           values["label"],
+		LabelingEnabled: values["labeling-enabled"],
+		MinConfidence:   values["min-confidence"],
+		ScanPRBody:      values["scan-pr-body"],
+		ExplicitInputs:  explicitInputs,
+		DefaultedInputs: defaultedInputs,
+	}
+}
+
+func configKey(ac ActionConfig) string {
+	parts := []string{
+		ac.SourceFile,
+		ac.ActionRef,
+		ac.Label,
+		ac.LabelingEnabled,
+		ac.MinConfidence,
+		ac.ScanPRBody,
+		strings.Join(ac.ExplicitInputs, ","),
+		strings.Join(ac.DefaultedInputs, ","),
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func sortConfigs(configs []ActionConfig) {
+	sort.Slice(configs, func(i, j int) bool {
+		return configKey(configs[i]) < configKey(configs[j])
+	})
+}
+
+func detectConfigsInWorkflow(sourceFile string, data []byte) ([]ActionConfig, error) {
+	var wf Workflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		return nil, err
+	}
+
+	var configs []ActionConfig
+	for _, job := range wf.Jobs {
+		for _, step := range job.Steps {
+			ref, ok := actionRef(step.Uses)
+			if !ok {
+				continue
+			}
+			configs = append(configs, actionConfig(sourceFile, ref, step.With))
+		}
+	}
+	return configs, nil
 }
 
 // DetectConfigs scans the .github/workflows directory for the chaoss/disclosure action
@@ -62,8 +154,9 @@ func DetectConfigs(repoPath string) (*Config, error) {
 		return nil, err
 	}
 
-	seenConfigs := make(map[ActionConfig]bool)
+	seenConfigs := make(map[string]bool)
 	configs := []ActionConfig{}
+	warnings := []Warning{}
 
 	for _, entry := range entries {
 		if entry.IsDir() {
@@ -74,48 +167,30 @@ func DetectConfigs(repoPath string) (*Config, error) {
 			continue
 		}
 
+		sourceFile := filepath.ToSlash(filepath.Join(".github", "workflows", entry.Name()))
 		path := filepath.Join(workflowsDir, entry.Name())
 		data, err := os.ReadFile(path)
 		if err != nil {
+			warnings = append(warnings, Warning{SourceFile: sourceFile, Error: err.Error()})
 			continue
 		}
 
-		var wf Workflow
-		if err := yaml.Unmarshal(data, &wf); err != nil {
+		fileConfigs, err := detectConfigsInWorkflow(sourceFile, data)
+		if err != nil {
+			warnings = append(warnings, Warning{SourceFile: sourceFile, Error: err.Error()})
 			continue
 		}
-
-		for _, job := range wf.Jobs {
-			for _, step := range job.Steps {
-				if isDisclosureActionUse(step.Uses) {
-					ac := ActionConfig{
-						Label:           getString(step.With, "label", "ai-detected"),
-						LabelingEnabled: getString(step.With, "labeling-enabled", "false"),
-						MinConfidence:   getString(step.With, "min-confidence", "low"),
-						ScanPRBody:      getString(step.With, "scan-pr-body", "true"),
-					}
-					if seenConfigs[ac] {
-						continue
-					}
-					seenConfigs[ac] = true
-					configs = append(configs, ac)
-				}
+		for _, ac := range fileConfigs {
+			key := configKey(ac)
+			if seenConfigs[key] {
+				continue
 			}
+			seenConfigs[key] = true
+			configs = append(configs, ac)
 		}
 	}
 
-	sort.Slice(configs, func(i, j int) bool {
-		if configs[i].Label != configs[j].Label {
-			return configs[i].Label < configs[j].Label
-		}
-		if configs[i].LabelingEnabled != configs[j].LabelingEnabled {
-			return configs[i].LabelingEnabled < configs[j].LabelingEnabled
-		}
-		if configs[i].MinConfidence != configs[j].MinConfidence {
-			return configs[i].MinConfidence < configs[j].MinConfidence
-		}
-		return configs[i].ScanPRBody < configs[j].ScanPRBody
-	})
+	sortConfigs(configs)
 
-	return &Config{Configs: configs}, nil
+	return &Config{Configs: configs, Warnings: warnings, Incomplete: len(warnings) > 0}, nil
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDetectLabels(t *testing.T) {
+func TestDetectConfigs(t *testing.T) {
 	tempDir := t.TempDir()
 	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
@@ -21,22 +21,35 @@ jobs:
       - uses: chaoss/disclosure@main
         with:
           label: custom-ai-label
+          min-confidence: medium
+          scan-pr-body: "false"
 `
 	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	config, err := DetectLabels(tempDir)
+	config, err := DetectConfigs(tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(config.Labels) != 1 || config.Labels[0] != "custom-ai-label" {
-		t.Fatalf("expected [custom-ai-label], got %v", config.Labels)
+	if len(config.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(config.Configs))
+	}
+	
+	ac := config.Configs[0]
+	if ac.Label != "custom-ai-label" {
+		t.Errorf("expected label custom-ai-label, got %v", ac.Label)
+	}
+	if ac.MinConfidence != "medium" {
+		t.Errorf("expected min-confidence medium, got %v", ac.MinConfidence)
+	}
+	if ac.ScanPRBody != "false" {
+		t.Errorf("expected scan-pr-body false, got %v", ac.ScanPRBody)
 	}
 }
 
-func TestDetectLabelsDefault(t *testing.T) {
+func TestDetectConfigsDefault(t *testing.T) {
 	tempDir := t.TempDir()
 	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
@@ -53,23 +66,34 @@ jobs:
 		t.Fatal(err)
 	}
 
-	config, err := DetectLabels(tempDir)
+	config, err := DetectConfigs(tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(config.Labels) != 1 || config.Labels[0] != "ai-detected" {
-		t.Fatalf("expected [ai-detected], got %v", config.Labels)
+	if len(config.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(config.Configs))
+	}
+	
+	ac := config.Configs[0]
+	if ac.Label != "ai-detected" {
+		t.Errorf("expected label ai-detected, got %v", ac.Label)
+	}
+	if ac.MinConfidence != "low" {
+		t.Errorf("expected min-confidence low, got %v", ac.MinConfidence)
+	}
+	if ac.ScanPRBody != "true" {
+		t.Errorf("expected scan-pr-body true, got %v", ac.ScanPRBody)
 	}
 }
 
-func TestDetectLabelsNoWorkflows(t *testing.T) {
+func TestDetectConfigsNoWorkflows(t *testing.T) {
 	tempDir := t.TempDir()
-	config, err := DetectLabels(tempDir)
+	config, err := DetectConfigs(tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(config.Labels) != 0 {
-		t.Fatalf("expected [], got %v", config.Labels)
+	if len(config.Configs) != 0 {
+		t.Fatalf("expected empty configs, got %v", config.Configs)
 	}
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -1,0 +1,75 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectLabels(t *testing.T) {
+	tempDir := t.TempDir()
+	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+jobs:
+  test:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chaoss/disclosure@main
+        with:
+          label: custom-ai-label
+`
+	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := DetectLabels(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Labels) != 1 || config.Labels[0] != "custom-ai-label" {
+		t.Fatalf("expected [custom-ai-label], got %v", config.Labels)
+	}
+}
+
+func TestDetectLabelsDefault(t *testing.T) {
+	tempDir := t.TempDir()
+	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+jobs:
+  test:
+    steps:
+      - uses: chaoss/disclosure@v1
+`
+	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := DetectLabels(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(config.Labels) != 1 || config.Labels[0] != "ai-detected" {
+		t.Fatalf("expected [ai-detected], got %v", config.Labels)
+	}
+}
+
+func TestDetectLabelsNoWorkflows(t *testing.T) {
+	tempDir := t.TempDir()
+	config, err := DetectLabels(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Labels) != 0 {
+		t.Fatalf("expected [], got %v", config.Labels)
+	}
+}

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -18,7 +18,7 @@ jobs:
   test:
     steps:
       - uses: actions/checkout@v4
-      - uses: chaoss/disclosure@main
+      - uses: chaoss/disclosure/action@main
         with:
           label: custom-ai-label
           labeling-enabled: "true"
@@ -64,7 +64,7 @@ func TestDetectConfigsDefault(t *testing.T) {
 jobs:
   test:
     steps:
-      - uses: chaoss/disclosure@v1
+      - uses: chaoss/disclosure/action@v1
 `
 	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
 		t.Fatal(err)
@@ -94,6 +94,72 @@ jobs:
 	}
 }
 
+func TestDetectConfigsReadmeSyntax(t *testing.T) {
+	tempDir := t.TempDir()
+	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+name: AI Disclosure
+on:
+  pull_request:
+jobs:
+  disclose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chaoss/disclosure/action@main
+`
+	if err := os.WriteFile(filepath.Join(workflowsDir, "ai_detection.yml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := DetectConfigs(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := ActionConfig{
+		Label:           "ai-detected",
+		LabelingEnabled: "false",
+		MinConfidence:   "low",
+		ScanPRBody:      "true",
+	}
+	if len(config.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d: %#v", len(config.Configs), config.Configs)
+	}
+	if config.Configs[0] != want {
+		t.Errorf("config = %#v, want %#v", config.Configs[0], want)
+	}
+}
+
+func TestDetectConfigsIgnoresRepositoryRootReference(t *testing.T) {
+	tempDir := t.TempDir()
+	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	yamlContent := `
+jobs:
+  test:
+    steps:
+      - uses: chaoss/disclosure@main
+`
+	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := DetectConfigs(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Configs) != 0 {
+		t.Fatalf("expected empty configs, got %#v", config.Configs)
+	}
+}
+
 func TestDetectConfigsNoWorkflows(t *testing.T) {
 	tempDir := t.TempDir()
 	config, err := DetectConfigs(tempDir)
@@ -116,7 +182,7 @@ func TestDetectConfigsMultipleSortedAndDeduplicated(t *testing.T) {
 jobs:
   test:
     steps:
-      - uses: chaoss/disclosure@main
+      - uses: chaoss/disclosure/action@main
         with:
           label: z-ai
           labeling-enabled: "true"
@@ -127,13 +193,13 @@ jobs:
 jobs:
   test:
     steps:
-      - uses: chaoss/disclosure@main
+      - uses: chaoss/disclosure/action@main
         with:
           label: a-ai
           labeling-enabled: "false"
           min-confidence: low
           scan-pr-body: "true"
-      - uses: chaoss/disclosure@main
+      - uses: chaoss/disclosure/action@main
         with:
           label: z-ai
           labeling-enabled: "true"

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -6,14 +6,62 @@ import (
 	"testing"
 )
 
-func TestDetectConfigs(t *testing.T) {
-	tempDir := t.TempDir()
-	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+func writeWorkflow(t *testing.T, repoPath, name, content string) {
+	t.Helper()
+
+	workflowsDir := filepath.Join(repoPath, ".github", "workflows")
 	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(workflowsDir, name), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
 
-	yamlContent := `
+func assertConfig(t *testing.T, got, want ActionConfig) {
+	t.Helper()
+
+	if got.SourceFile != want.SourceFile {
+		t.Errorf("source_file = %q, want %q", got.SourceFile, want.SourceFile)
+	}
+	if got.ActionRef != want.ActionRef {
+		t.Errorf("action_ref = %q, want %q", got.ActionRef, want.ActionRef)
+	}
+	if got.Label != want.Label {
+		t.Errorf("label = %q, want %q", got.Label, want.Label)
+	}
+	if got.LabelingEnabled != want.LabelingEnabled {
+		t.Errorf("labeling_enabled = %q, want %q", got.LabelingEnabled, want.LabelingEnabled)
+	}
+	if got.MinConfidence != want.MinConfidence {
+		t.Errorf("min_confidence = %q, want %q", got.MinConfidence, want.MinConfidence)
+	}
+	if got.ScanPRBody != want.ScanPRBody {
+		t.Errorf("scan_pr_body = %q, want %q", got.ScanPRBody, want.ScanPRBody)
+	}
+	if !sameStrings(got.ExplicitInputs, want.ExplicitInputs) {
+		t.Errorf("explicit_inputs = %v, want %v", got.ExplicitInputs, want.ExplicitInputs)
+	}
+	if !sameStrings(got.DefaultedInputs, want.DefaultedInputs) {
+		t.Errorf("defaulted_inputs = %v, want %v", got.DefaultedInputs, want.DefaultedInputs)
+	}
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestDetectConfigs(t *testing.T) {
+	tempDir := t.TempDir()
+	writeWorkflow(t, tempDir, "test.yml", `
 jobs:
   test:
     steps:
@@ -24,10 +72,7 @@ jobs:
           labeling-enabled: "true"
           min-confidence: medium
           scan-pr-body: "false"
-`
-	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	config, err := DetectConfigs(tempDir)
 	if err != nil {
@@ -37,38 +82,29 @@ jobs:
 	if len(config.Configs) != 1 {
 		t.Fatalf("expected 1 config, got %d", len(config.Configs))
 	}
-
-	ac := config.Configs[0]
-	if ac.Label != "custom-ai-label" {
-		t.Errorf("expected label custom-ai-label, got %v", ac.Label)
+	if config.Incomplete {
+		t.Fatal("expected complete result")
 	}
-	if ac.LabelingEnabled != "true" {
-		t.Errorf("expected labeling-enabled true, got %v", ac.LabelingEnabled)
-	}
-	if ac.MinConfidence != "medium" {
-		t.Errorf("expected min-confidence medium, got %v", ac.MinConfidence)
-	}
-	if ac.ScanPRBody != "false" {
-		t.Errorf("expected scan-pr-body false, got %v", ac.ScanPRBody)
-	}
+	assertConfig(t, config.Configs[0], ActionConfig{
+		SourceFile:      ".github/workflows/test.yml",
+		ActionRef:       "main",
+		Label:           "custom-ai-label",
+		LabelingEnabled: "true",
+		MinConfidence:   "medium",
+		ScanPRBody:      "false",
+		ExplicitInputs:  []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"},
+		DefaultedInputs: nil,
+	})
 }
 
 func TestDetectConfigsDefault(t *testing.T) {
 	tempDir := t.TempDir()
-	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
-	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	yamlContent := `
+	writeWorkflow(t, tempDir, "test.yml", `
 jobs:
   test:
     steps:
       - uses: chaoss/disclosure/action@v1
-`
-	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	config, err := DetectConfigs(tempDir)
 	if err != nil {
@@ -78,30 +114,21 @@ jobs:
 	if len(config.Configs) != 1 {
 		t.Fatalf("expected 1 config, got %d", len(config.Configs))
 	}
-
-	ac := config.Configs[0]
-	if ac.Label != "ai-detected" {
-		t.Errorf("expected label ai-detected, got %v", ac.Label)
-	}
-	if ac.LabelingEnabled != "false" {
-		t.Errorf("expected labeling-enabled false, got %v", ac.LabelingEnabled)
-	}
-	if ac.MinConfidence != "low" {
-		t.Errorf("expected min-confidence low, got %v", ac.MinConfidence)
-	}
-	if ac.ScanPRBody != "true" {
-		t.Errorf("expected scan-pr-body true, got %v", ac.ScanPRBody)
-	}
+	assertConfig(t, config.Configs[0], ActionConfig{
+		SourceFile:      ".github/workflows/test.yml",
+		ActionRef:       "v1",
+		Label:           "ai-detected",
+		LabelingEnabled: "false",
+		MinConfidence:   "low",
+		ScanPRBody:      "true",
+		ExplicitInputs:  nil,
+		DefaultedInputs: []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"},
+	})
 }
 
 func TestDetectConfigsReadmeSyntax(t *testing.T) {
 	tempDir := t.TempDir()
-	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
-	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	yamlContent := `
+	writeWorkflow(t, tempDir, "ai_detection.yml", `
 name: AI Disclosure
 on:
   pull_request:
@@ -110,46 +137,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: chaoss/disclosure/action@main
-`
-	if err := os.WriteFile(filepath.Join(workflowsDir, "ai_detection.yml"), []byte(yamlContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	config, err := DetectConfigs(tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	want := ActionConfig{
+	if len(config.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d: %#v", len(config.Configs), config.Configs)
+	}
+	assertConfig(t, config.Configs[0], ActionConfig{
+		SourceFile:      ".github/workflows/ai_detection.yml",
+		ActionRef:       "main",
 		Label:           "ai-detected",
 		LabelingEnabled: "false",
 		MinConfidence:   "low",
 		ScanPRBody:      "true",
-	}
-	if len(config.Configs) != 1 {
-		t.Fatalf("expected 1 config, got %d: %#v", len(config.Configs), config.Configs)
-	}
-	if config.Configs[0] != want {
-		t.Errorf("config = %#v, want %#v", config.Configs[0], want)
-	}
+		ExplicitInputs:  nil,
+		DefaultedInputs: []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"},
+	})
 }
 
 func TestDetectConfigsIgnoresRepositoryRootReference(t *testing.T) {
 	tempDir := t.TempDir()
-	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
-	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	yamlContent := `
+	writeWorkflow(t, tempDir, "test.yml", `
 jobs:
   test:
     steps:
       - uses: chaoss/disclosure@main
-`
-	if err := os.WriteFile(filepath.Join(workflowsDir, "test.yml"), []byte(yamlContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	config, err := DetectConfigs(tempDir)
 	if err != nil {
@@ -161,24 +178,21 @@ jobs:
 }
 
 func TestDetectConfigsNoWorkflows(t *testing.T) {
-	tempDir := t.TempDir()
-	config, err := DetectConfigs(tempDir)
+	config, err := DetectConfigs(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(config.Configs) != 0 {
 		t.Fatalf("expected empty configs, got %v", config.Configs)
 	}
+	if config.Incomplete {
+		t.Fatal("expected complete result")
+	}
 }
 
 func TestDetectConfigsMultipleSortedAndDeduplicated(t *testing.T) {
 	tempDir := t.TempDir()
-	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
-	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	firstWorkflow := `
+	writeWorkflow(t, tempDir, "z.yml", `
 jobs:
   test:
     steps:
@@ -188,8 +202,8 @@ jobs:
           labeling-enabled: "true"
           min-confidence: high
           scan-pr-body: "false"
-`
-	secondWorkflow := `
+`)
+	writeWorkflow(t, tempDir, "a.yml", `
 jobs:
   test:
     steps:
@@ -201,17 +215,11 @@ jobs:
           scan-pr-body: "true"
       - uses: chaoss/disclosure/action@main
         with:
-          label: z-ai
-          labeling-enabled: "true"
-          min-confidence: high
-          scan-pr-body: "false"
-`
-	if err := os.WriteFile(filepath.Join(workflowsDir, "z.yml"), []byte(firstWorkflow), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workflowsDir, "a.yml"), []byte(secondWorkflow), 0644); err != nil {
-		t.Fatal(err)
-	}
+          label: a-ai
+          labeling-enabled: "false"
+          min-confidence: low
+          scan-pr-body: "true"
+`)
 
 	config, err := DetectConfigs(tempDir)
 	if err != nil {
@@ -220,24 +228,66 @@ jobs:
 
 	want := []ActionConfig{
 		{
+			SourceFile:      ".github/workflows/a.yml",
+			ActionRef:       "main",
 			Label:           "a-ai",
 			LabelingEnabled: "false",
 			MinConfidence:   "low",
 			ScanPRBody:      "true",
+			ExplicitInputs:  []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"},
+			DefaultedInputs: nil,
 		},
 		{
+			SourceFile:      ".github/workflows/z.yml",
+			ActionRef:       "main",
 			Label:           "z-ai",
 			LabelingEnabled: "true",
 			MinConfidence:   "high",
 			ScanPRBody:      "false",
+			ExplicitInputs:  []string{"label", "labeling-enabled", "min-confidence", "scan-pr-body"},
+			DefaultedInputs: nil,
 		},
 	}
 	if len(config.Configs) != len(want) {
 		t.Fatalf("expected %d configs, got %d: %#v", len(want), len(config.Configs), config.Configs)
 	}
 	for i := range want {
-		if config.Configs[i] != want[i] {
-			t.Errorf("config[%d] = %#v, want %#v", i, config.Configs[i], want[i])
-		}
+		assertConfig(t, config.Configs[i], want[i])
+	}
+}
+
+func TestDetectConfigsWarningsForInvalidWorkflow(t *testing.T) {
+	tempDir := t.TempDir()
+	writeWorkflow(t, tempDir, "valid.yml", `
+jobs:
+  test:
+    steps:
+      - uses: chaoss/disclosure/action@main
+`)
+	writeWorkflow(t, tempDir, "invalid.yml", `
+jobs:
+  test:
+    steps:
+      - uses: [
+`)
+
+	config, err := DetectConfigs(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(config.Configs))
+	}
+	if !config.Incomplete {
+		t.Fatal("expected incomplete result")
+	}
+	if len(config.Warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %#v", config.Warnings)
+	}
+	if config.Warnings[0].SourceFile != ".github/workflows/invalid.yml" {
+		t.Errorf("warning source_file = %q", config.Warnings[0].SourceFile)
+	}
+	if config.Warnings[0].Error == "" {
+		t.Error("expected warning error")
 	}
 }

--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -21,6 +21,7 @@ jobs:
       - uses: chaoss/disclosure@main
         with:
           label: custom-ai-label
+          labeling-enabled: "true"
           min-confidence: medium
           scan-pr-body: "false"
 `
@@ -36,10 +37,13 @@ jobs:
 	if len(config.Configs) != 1 {
 		t.Fatalf("expected 1 config, got %d", len(config.Configs))
 	}
-	
+
 	ac := config.Configs[0]
 	if ac.Label != "custom-ai-label" {
 		t.Errorf("expected label custom-ai-label, got %v", ac.Label)
+	}
+	if ac.LabelingEnabled != "true" {
+		t.Errorf("expected labeling-enabled true, got %v", ac.LabelingEnabled)
 	}
 	if ac.MinConfidence != "medium" {
 		t.Errorf("expected min-confidence medium, got %v", ac.MinConfidence)
@@ -74,10 +78,13 @@ jobs:
 	if len(config.Configs) != 1 {
 		t.Fatalf("expected 1 config, got %d", len(config.Configs))
 	}
-	
+
 	ac := config.Configs[0]
 	if ac.Label != "ai-detected" {
 		t.Errorf("expected label ai-detected, got %v", ac.Label)
+	}
+	if ac.LabelingEnabled != "false" {
+		t.Errorf("expected labeling-enabled false, got %v", ac.LabelingEnabled)
 	}
 	if ac.MinConfidence != "low" {
 		t.Errorf("expected min-confidence low, got %v", ac.MinConfidence)
@@ -95,5 +102,76 @@ func TestDetectConfigsNoWorkflows(t *testing.T) {
 	}
 	if len(config.Configs) != 0 {
 		t.Fatalf("expected empty configs, got %v", config.Configs)
+	}
+}
+
+func TestDetectConfigsMultipleSortedAndDeduplicated(t *testing.T) {
+	tempDir := t.TempDir()
+	workflowsDir := filepath.Join(tempDir, ".github", "workflows")
+	if err := os.MkdirAll(workflowsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	firstWorkflow := `
+jobs:
+  test:
+    steps:
+      - uses: chaoss/disclosure@main
+        with:
+          label: z-ai
+          labeling-enabled: "true"
+          min-confidence: high
+          scan-pr-body: "false"
+`
+	secondWorkflow := `
+jobs:
+  test:
+    steps:
+      - uses: chaoss/disclosure@main
+        with:
+          label: a-ai
+          labeling-enabled: "false"
+          min-confidence: low
+          scan-pr-body: "true"
+      - uses: chaoss/disclosure@main
+        with:
+          label: z-ai
+          labeling-enabled: "true"
+          min-confidence: high
+          scan-pr-body: "false"
+`
+	if err := os.WriteFile(filepath.Join(workflowsDir, "z.yml"), []byte(firstWorkflow), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workflowsDir, "a.yml"), []byte(secondWorkflow), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := DetectConfigs(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []ActionConfig{
+		{
+			Label:           "a-ai",
+			LabelingEnabled: "false",
+			MinConfidence:   "low",
+			ScanPRBody:      "true",
+		},
+		{
+			Label:           "z-ai",
+			LabelingEnabled: "true",
+			MinConfidence:   "high",
+			ScanPRBody:      "false",
+		},
+	}
+	if len(config.Configs) != len(want) {
+		t.Fatalf("expected %d configs, got %d: %#v", len(want), len(config.Configs), config.Configs)
+	}
+	for i := range want {
+		if config.Configs[i] != want[i] {
+			t.Errorf("config[%d] = %#v, want %#v", i, config.Configs[i], want[i])
+		}
 	}
 }


### PR DESCRIPTION
fixes #16

### descirption
Downstream tools (like Augur) that use this application to analyze repositories need to dynamically detect which label the maintainers have configured for AI usage. Previously, this required downstream tools to implement their own YAML parsers to figure it out...

This PR shifts that responsibility natively into the CLI, allowing it to inspect a repository's `.github/workflows` directory and expose the configured labels in a clean JSON format...

### Changes Made
- **Dependency Added**: Added `gopkg.in/yaml.v3` to robustly parse GitHub Action workflow files.
- **Workflow Scanner**: Created the `workflow` package which scans `.github/workflows/*.yml`, identifying any usage of `chaoss/disclosure`. It parses out the explicit `with: label:` parameter or correctly falls back to the default `ai-detected` label.
- **CLI Subcommand**: Added the `disclosure actions [repo-path]` subcommand to output the discovered labels in a machine-readable JSON format: `{"labels": ["ai-detected"]}`.
- **Testing**: Added rigorous unit tests in `workflow_test.go` to ensure accurate extraction logic and defaults.

### Testing
- `go test ./...` passes cleanly.
- Running `disclosure actions .` against a repo containing the action correctly surfaces the AI labels in JSON.