### PR TITLE
Separate out parsing logic from detectors

### DIFF
--- a/detection/committer/committer.go
+++ b/detection/committer/committer.go
@@ -25,9 +25,9 @@ type Detector struct{}
 func (d *Detector) Name() string { return "committer" }
 
 func (d *Detector) Detect(input detection.Input) []detection.Finding {
-	email := strings.ToLower(strings.TrimSpace(input.CommitEmail))
-	if email == "" {
-		return nil
+	email, err := input.GetCommitEmail()
+	if err != nil {
+		return []detection.Finding{}
 	}
 
 	// Direct match against known emails

--- a/detection/constants.go
+++ b/detection/constants.go
@@ -88,3 +88,6 @@ var ReplitAttributionRegex = `(?m)^Replit-Commit-Author:\s*(Agent|Assistant)(?:\
 
 // GitNotesAuthorshipPrefix Authorship prefix to check as a precondition in git notes
 var GitNotesAuthorshipPrefix = "authorship/"
+
+// TrailerEmailPattern Regex to match email address in commit trailers
+var TrailerEmailPattern = regexp.MustCompile(`\s*<[^>]+>`)

--- a/detection/detection.go
+++ b/detection/detection.go
@@ -1,5 +1,10 @@
 package detection
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Confidence represents how confident we are that a finding indicates AI involvement.
 type Confidence int
 
@@ -34,6 +39,12 @@ type Finding struct {
 	Detail     string     `json:"detail"`
 }
 
+// Detector is the interface that all detection strategies implement.
+type Detector interface {
+	Name() string
+	Detect(input Input) []Finding
+}
+
 // Input provides data for detectors to examine. Each detector reads the fields
 // it cares about and ignores the rest.
 type Input struct {
@@ -45,8 +56,32 @@ type Input struct {
 	RepoPath      string
 }
 
-// Detector is the interface that all detection strategies implement.
-type Detector interface {
-	Name() string
-	Detect(input Input) []Finding
+func (input *Input) GetCommitEmail() (string, error) {
+	return getCommitField(input.CommitEmail, fieldCommitEmail)
+}
+
+func (input *Input) GetCommitMessage() (string, error) {
+	return getCommitField(input.CommitMessage, fieldCommitMessage)
+}
+
+func (input *Input) GetTextWithCommitMessage() (string, error) {
+	text := strings.TrimSpace(input.Text)
+	commitMessage, _ := input.GetCommitMessage()
+
+	var result []string
+	if text != "" {
+		result = append(result, text)
+	}
+	if commitMessage != "" {
+		result = append(result, commitMessage)
+	}
+	if len(result) == 0 {
+		return "", fmt.Errorf("no text or commit message, blank contents")
+	}
+
+	return strings.Join(result, "\n"), nil
+}
+
+func (input *Input) GetNotes() (GitnoteParseResult, error) {
+	return parseGitnotes(input.Notes)
 }

--- a/detection/gitnotes/gitnotes.go
+++ b/detection/gitnotes/gitnotes.go
@@ -1,70 +1,24 @@
 package gitnotes
 
 import (
-	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/chaoss/disclosure/detection"
 )
-
-// metadata represents the JSON metadata section of a git-ai authorship log.
-type metadata struct {
-	SchemaVersion string                  `json:"schema_version"`
-	Prompts       map[string]promptRecord `json:"prompts"`
-}
-
-type promptRecord struct {
-	AgentID agentID `json:"agent_id"`
-}
-
-type agentID struct {
-	Tool  string `json:"tool"`
-	Model string `json:"model"`
-}
 
 type Detector struct{}
 
 func (d *Detector) Name() string { return "gitnotes" }
 
 func (d *Detector) Detect(input detection.Input) []detection.Finding {
-	if input.Notes == "" {
-		return nil
-	}
-
-	parts := strings.SplitN(input.Notes, "\n---\n", 2)
-	if len(parts) != 2 {
-		return nil
-	}
-
-	attestation := parts[0]
-	jsonSection := parts[1]
-
-	var meta metadata
-	if err := json.Unmarshal([]byte(jsonSection), &meta); err != nil {
-		return nil
-	}
-
-	if !strings.HasPrefix(meta.SchemaVersion, detection.GitNotesAuthorshipPrefix) {
-		return nil
-	}
-
-	// Count attributed files from the attestation section
-	fileCount := 0
-	for _, line := range strings.Split(attestation, "\n") {
-		if line == "" {
-			continue
-		}
-		// File paths start at column 0, attestation entries are indented
-		if !strings.HasPrefix(line, " ") {
-			fileCount++
-		}
+	parseResult, err := input.GetNotes()
+	if err != nil {
+		return []detection.Finding{}
 	}
 
 	seen := map[string]bool{}
 	var findings []detection.Finding
-
-	for _, prompt := range meta.Prompts {
+	for _, prompt := range parseResult.Metadata.Prompts {
 		tool := prompt.AgentID.Tool
 		if tool == "" || seen[tool] {
 			continue
@@ -75,8 +29,8 @@ func (d *Detector) Detect(input detection.Input) []detection.Finding {
 		if prompt.AgentID.Model != "" {
 			detail += fmt.Sprintf(" (model: %s)", prompt.AgentID.Model)
 		}
-		if fileCount > 0 {
-			detail += fmt.Sprintf(", %d file(s) attributed", fileCount)
+		if parseResult.AttributionFileCount > 0 {
+			detail += fmt.Sprintf(", %d file(s) attributed", parseResult.AttributionFileCount)
 		}
 
 		findings = append(findings, detection.Finding{

--- a/detection/parsing.go
+++ b/detection/parsing.go
@@ -1,0 +1,91 @@
+package detection
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type GitnoteParseResult struct {
+	Metadata             metadata `json:"metadata"`
+	AttributionFileCount int      `json:"attribution_file_count"`
+}
+
+// metadata represents the JSON metadata section of a git-ai authorship log.
+type metadata struct {
+	SchemaVersion string                  `json:"schema_version"`
+	Prompts       map[string]promptRecord `json:"prompts"`
+}
+
+type promptRecord struct {
+	AgentID agentID `json:"agent_id"`
+}
+
+type agentID struct {
+	Tool  string `json:"tool"`
+	Model string `json:"model"`
+}
+
+var (
+	fieldCommitEmail   = "commit_email"
+	fieldCommitMessage = "commit_message"
+)
+
+func getCommitField(value string, field string) (string, error) {
+	value = strings.TrimSpace(value)
+
+	if value == "" {
+		return "", fmt.Errorf("%s is empty", field)
+	}
+
+	switch field {
+	case fieldCommitEmail:
+		return strings.ToLower(value), nil
+
+	case fieldCommitMessage:
+		return value, nil
+
+	default:
+		return "", fmt.Errorf("unsupported field: %s", field)
+	}
+}
+
+func parseGitnotes(notes string) (GitnoteParseResult, error) {
+	if notes == "" {
+		return GitnoteParseResult{}, fmt.Errorf("no notes found in input")
+	}
+
+	parts := strings.SplitN(notes, "\n---\n", 2)
+	if len(parts) != 2 {
+		return GitnoteParseResult{}, fmt.Errorf("missing parts in notes, unable to parse")
+	}
+
+	attestation := parts[0]
+	jsonSection := parts[1]
+
+	var meta metadata
+	if err := json.Unmarshal([]byte(jsonSection), &meta); err != nil {
+		return GitnoteParseResult{}, fmt.Errorf("unable to unmarshal notes json")
+	}
+
+	if !strings.HasPrefix(meta.SchemaVersion, GitNotesAuthorshipPrefix) {
+		return GitnoteParseResult{}, fmt.Errorf("authorship prefix missing in schema version")
+	}
+
+	// Count attributed files from the attestation section
+	fileCount := 0
+	for line := range strings.SplitSeq(attestation, "\n") {
+		if line == "" {
+			continue
+		}
+		// File paths start at column 0, attestation entries are indented
+		if !strings.HasPrefix(line, " ") {
+			fileCount++
+		}
+	}
+
+	return GitnoteParseResult{
+		Metadata:             meta,
+		AttributionFileCount: fileCount,
+	}, nil
+}

--- a/detection/toolmention/toolmention.go
+++ b/detection/toolmention/toolmention.go
@@ -3,7 +3,6 @@ package toolmention
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/chaoss/disclosure/detection"
 )
@@ -30,22 +29,13 @@ type Detector struct{}
 func (d *Detector) Name() string { return "toolmention" }
 
 func (d *Detector) Detect(input detection.Input) []detection.Finding {
-	text := input.Text
-	if input.CommitMessage != "" {
-		if text != "" {
-			text = text + "\n" + input.CommitMessage
-		} else {
-			text = input.CommitMessage
-		}
-	}
-
-	if strings.TrimSpace(text) == "" {
-		return nil
+	text, err := input.GetTextWithCommitMessage()
+	if err != nil {
+		return []detection.Finding{}
 	}
 
 	var findings []detection.Finding
 	seen := map[string]bool{}
-
 	for _, tp := range toolPatterns {
 		if seen[tp.name] {
 			continue

--- a/detection/toolmention/toolmention_test.go
+++ b/detection/toolmention/toolmention_test.go
@@ -55,6 +55,11 @@ func TestDetect(t *testing.T) {
 			wantTools: nil,
 		},
 		{
+			name:      "empty input with spaces",
+			input:     detection.Input{Text: "   ", CommitMessage: "\n   \n"},
+			wantTools: nil,
+		},
+		{
 			name:      "empty input",
 			input:     detection.Input{},
 			wantTools: nil,

--- a/detection/trailer/trailer.go
+++ b/detection/trailer/trailer.go
@@ -11,26 +11,24 @@ import (
 	"golang.org/x/text/language"
 )
 
-var trailerEmailPattern = regexp.MustCompile(`\s*<[^>]+>`)
-
-func extractToolFromText(text string) string {
+func extractToolFromText(text string) (string, error) {
 	text = strings.TrimSpace(text)
 	if text == "" {
-		return ""
+		return "", fmt.Errorf("empty text found")
 	}
 
 	// removing the email part e.g. Aider <noreply@aider.chat>
-	text = strings.TrimSpace(trailerEmailPattern.ReplaceAllString(text, ""))
+	text = strings.TrimSpace(detection.TrailerEmailPattern.ReplaceAllString(text, ""))
 
 	// trimming any values in brackets e.g. Claude (Anthropic)
 	text, _, _ = strings.Cut(text, "(")
 
 	text = strings.TrimSpace(text)
 	if text == "" {
-		return ""
+		return "", fmt.Errorf("no contents found in text")
 	}
 
-	return cases.Title(language.English, cases.NoLower).String(text)
+	return cases.Title(language.English, cases.NoLower).String(text), nil
 }
 
 var commitMessagePatterns = []struct {
@@ -96,10 +94,10 @@ type Detector struct{}
 
 func (d *Detector) Name() string { return "trailer" }
 
-func (d *Detector) detectTrailerCoauthoredBy(input detection.Input) []detection.Finding {
+func (d *Detector) detectTrailerCoauthoredBy(commitMessage string) []detection.Finding {
 	var findings []detection.Finding
 
-	matches := detection.CoAuthorPattern.FindAllStringSubmatch(input.CommitMessage, -1)
+	matches := detection.CoAuthorPattern.FindAllStringSubmatch(commitMessage, -1)
 	if len(matches) == 0 {
 		return findings
 	}
@@ -122,10 +120,10 @@ func (d *Detector) detectTrailerCoauthoredBy(input detection.Input) []detection.
 	return findings
 }
 
-func (d *Detector) detectTrailerAssistedBy(input detection.Input) []detection.Finding {
+func (d *Detector) detectTrailerAssistedBy(commitMessage string) []detection.Finding {
 	var findings []detection.Finding
 
-	matches := detection.AssistedByPattern.FindAllStringSubmatch(input.CommitMessage, -1)
+	matches := detection.AssistedByPattern.FindAllStringSubmatch(commitMessage, -1)
 	if len(matches) == 0 {
 		return findings
 	}
@@ -136,8 +134,8 @@ func (d *Detector) detectTrailerAssistedBy(input detection.Input) []detection.Fi
 			continue
 		}
 
-		matchedTool := extractToolFromText(match[1])
-		if matchedTool == "" || seen[matchedTool] {
+		matchedTool, err := extractToolFromText(match[1])
+		if err != nil || seen[matchedTool] {
 			continue
 		}
 
@@ -152,10 +150,10 @@ func (d *Detector) detectTrailerAssistedBy(input detection.Input) []detection.Fi
 	return findings
 }
 
-func (d *Detector) detectMessagePatterns(input detection.Input) []detection.Finding {
+func (d *Detector) detectMessagePatterns(commitMessage string) []detection.Finding {
 	var findings []detection.Finding
 	for _, p := range commitMessagePatterns {
-		if confidence, isDetected := p.check(input.CommitMessage); isDetected {
+		if confidence, isDetected := p.check(commitMessage); isDetected {
 			findings = append(findings, detection.Finding{
 				Detector:   d.Name(),
 				Tool:       p.name,
@@ -168,18 +166,19 @@ func (d *Detector) detectMessagePatterns(input detection.Input) []detection.Find
 }
 
 func (d *Detector) Detect(input detection.Input) []detection.Finding {
-	if input.CommitMessage == "" {
-		return nil
+	commitMessage, err := input.GetCommitMessage()
+	if err != nil {
+		return []detection.Finding{}
 	}
 
 	return slices.Concat(
 		// add findings for co-authored-by
-		d.detectTrailerCoauthoredBy(input),
+		d.detectTrailerCoauthoredBy(commitMessage),
 
 		// add findings for assisted-by
-		d.detectTrailerAssistedBy(input),
+		d.detectTrailerAssistedBy(commitMessage),
 
 		// add findings for other custom trailers
-		d.detectMessagePatterns(input),
+		d.detectMessagePatterns(commitMessage),
 	)
 }


### PR DESCRIPTION
Closes #54.

This is a refactor-only PR that separates out the detection-related parsing logic from the detectors and keeps it in parsing.go. Additionally this fixes return from [nil to []detection.Finding](https://github.com/chaoss/disclosure/compare/main...omkar-foss:chaoss-disclosure:keep-parsing-separate?expand=1#diff-be5081c19e02647676842b0e9c077caea4cb3bfcb3fc3237384157fac0e3f741R30) for consistency across all detectors, and [adds a case](https://github.com/chaoss/disclosure/compare/main...omkar-foss:chaoss-disclosure:keep-parsing-separate?expand=1#diff-bea8960a3fcf68083bf3c7caadbbc7f9ecd7268e42966899ddde8af27dda117eR57-R61) in test related to empty text.