### PR TITLE
Compile Replit attribution regex once

### DIFF
--- a/detection/constants.go
+++ b/detection/constants.go
@@ -86,6 +86,9 @@ var EntireIOTrailers = []string{
 // ReplitAttributionRegex Regex to detect use of Replit Agent or Assistant
 var ReplitAttributionRegex = `(?m)^Replit-Commit-Author:\s*(Agent|Assistant)(?:\r?\nReplit-Commit-Session-Id:\s*([a-fA-F0-9-]+))?(?:\r?\n|$)`
 
+// ReplitAttributionPattern compiled pattern for Replit Agent or Assistant attribution
+var ReplitAttributionPattern = regexp.MustCompile(ReplitAttributionRegex)
+
 // GitNotesAuthorshipPrefix Authorship prefix to check as a precondition in git notes
 var GitNotesAuthorshipPrefix = "authorship/"
 

--- a/detection/trailer/trailer.go
+++ b/detection/trailer/trailer.go
@@ -2,7 +2,6 @@ package trailer
 
 import (
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -30,8 +29,6 @@ func extractToolFromText(text string) (string, error) {
 
 	return cases.Title(language.English, cases.NoLower).String(text), nil
 }
-
-var replitAttributionPattern = regexp.MustCompile(detection.ReplitAttributionRegex)
 
 var commitMessagePatterns = []struct {
 	check func(string) (detection.Confidence, bool)
@@ -62,7 +59,7 @@ var commitMessagePatterns = []struct {
 	},
 	{
 		check: func(msg string) (detection.Confidence, bool) {
-			matchResult := replitAttributionPattern.FindStringSubmatch(msg)
+			matchResult := detection.ReplitAttributionPattern.FindStringSubmatch(msg)
 			if len(matchResult) == 0 {
 				// replit not detected
 				return detection.ConfidenceMedium, false

--- a/detection/trailer/trailer.go
+++ b/detection/trailer/trailer.go
@@ -31,6 +31,8 @@ func extractToolFromText(text string) (string, error) {
 	return cases.Title(language.English, cases.NoLower).String(text), nil
 }
 
+var replitAttributionPattern = regexp.MustCompile(detection.ReplitAttributionRegex)
+
 var commitMessagePatterns = []struct {
 	check func(string) (detection.Confidence, bool)
 	name  string
@@ -60,9 +62,7 @@ var commitMessagePatterns = []struct {
 	},
 	{
 		check: func(msg string) (detection.Confidence, bool) {
-			trailerRegex := regexp.MustCompile(detection.ReplitAttributionRegex)
-
-			matchResult := trailerRegex.FindStringSubmatch(msg)
+			matchResult := replitAttributionPattern.FindStringSubmatch(msg)
 			if len(matchResult) == 0 {
 				// replit not detected
 				return detection.ConfidenceMedium, false

--- a/detection/trailer/trailer_test.go
+++ b/detection/trailer/trailer_test.go
@@ -455,3 +455,30 @@ Signed-off-by: some human <test@example.com>
 		})
 	}
 }
+
+func BenchmarkDetect(b *testing.B) {
+	d := &Detector{}
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "no match",
+			message: "fix: handle an ordinary commit without attribution",
+		},
+		{
+			name:    "Replit match",
+			message: "feat: update handler\n\nReplit-Commit-Author: Agent\nReplit-Commit-Session-Id: 1234a1ab-12ab-1234-abcd-0123456a1234",
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			input := detection.Input{CommitMessage: tt.message}
+			b.ReportAllocs()
+			for range b.N {
+				d.Detect(input)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Compile `ReplitAttributionRegex` once when the trailer package initializes instead of recompiling it for every commit message.

Add benchmarks for an ordinary no-match message and a Replit attribution with a session ID so later detector changes can be compared against the same paths.