### PR TITLE
Detect AI agent authors and committers

### DIFF
--- a/detection/committer/committer.go
+++ b/detection/committer/committer.go
@@ -24,19 +24,14 @@ type Detector struct{}
 
 func (d *Detector) Name() string { return "committer" }
 
-func (d *Detector) Detect(input detection.Input) []detection.Finding {
-	email, err := input.GetCommitEmail()
-	if err != nil {
-		return []detection.Finding{}
-	}
-
+func (d *Detector) detectEmail(email, identityField string) []detection.Finding {
 	// Direct match against known emails
 	if name, ok := detection.KnownAgentCommitters[email]; ok {
 		return []detection.Finding{{
 			Detector:   d.Name(),
 			Tool:       name,
 			Confidence: detection.ConfidenceHigh,
-			Detail:     fmt.Sprintf("committer email %s matches known AI bot", email),
+			Detail:     fmt.Sprintf("%s email %s matches known AI bot", identityField, email),
 		}}
 	}
 
@@ -50,11 +45,23 @@ func (d *Detector) Detect(input detection.Input) []detection.Finding {
 					Detector:   d.Name(),
 					Tool:       name,
 					Confidence: detection.ConfidenceHigh,
-					Detail:     fmt.Sprintf("committer email %s matches known AI bot", email),
+					Detail:     fmt.Sprintf("%s email %s matches known AI bot", identityField, email),
 				}}
 			}
 		}
 	}
 
 	return nil
+}
+
+func (d *Detector) Detect(input detection.Input) []detection.Finding {
+	authorEmail, _ := input.GetAuthorEmail()
+	committerEmail, _ := input.GetCommitEmail()
+
+	if authorEmail != "" && authorEmail == committerEmail {
+		return d.detectEmail(authorEmail, "author and committer")
+	}
+
+	findings := d.detectEmail(authorEmail, "author")
+	return append(findings, d.detectEmail(committerEmail, "committer")...)
 }

--- a/detection/committer/committer_test.go
+++ b/detection/committer/committer_test.go
@@ -130,3 +130,85 @@ func TestDetectNumericPrefixNoFalsePositive(t *testing.T) {
 		}
 	}
 }
+
+func TestDetectAuthorAndCommitter(t *testing.T) {
+	const (
+		claudeEmail  = "209825114+claude[bot]@users.noreply.github.com"
+		copilotEmail = "198982749+copilot@users.noreply.github.com"
+		humanEmail   = "human@example.com"
+	)
+
+	d := &Detector{}
+	tests := []struct {
+		name        string
+		input       detection.Input
+		wantTools   []string
+		wantDetails []string
+	}{
+		{
+			name: "author only",
+			input: detection.Input{
+				AuthorEmail: copilotEmail,
+				CommitEmail: humanEmail,
+			},
+			wantTools: []string{detection.KnownAgentCommitters[copilotEmail]},
+			wantDetails: []string{
+				"author email " + copilotEmail + " matches known AI bot",
+			},
+		},
+		{
+			name: "committer only",
+			input: detection.Input{
+				AuthorEmail: humanEmail,
+				CommitEmail: claudeEmail,
+			},
+			wantTools: []string{detection.KnownAgentCommitters[claudeEmail]},
+			wantDetails: []string{
+				"committer email " + claudeEmail + " matches known AI bot",
+			},
+		},
+		{
+			name: "different agent identities",
+			input: detection.Input{
+				AuthorEmail: copilotEmail,
+				CommitEmail: claudeEmail,
+			},
+			wantTools: []string{
+				detection.KnownAgentCommitters[copilotEmail],
+				detection.KnownAgentCommitters[claudeEmail],
+			},
+			wantDetails: []string{
+				"author email " + copilotEmail + " matches known AI bot",
+				"committer email " + claudeEmail + " matches known AI bot",
+			},
+		},
+		{
+			name: "same identity in both fields",
+			input: detection.Input{
+				AuthorEmail: copilotEmail,
+				CommitEmail: copilotEmail,
+			},
+			wantTools: []string{detection.KnownAgentCommitters[copilotEmail]},
+			wantDetails: []string{
+				"author and committer email " + copilotEmail + " matches known AI bot",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := d.Detect(tt.input)
+			if len(findings) != len(tt.wantTools) {
+				t.Fatalf("got %d findings, want %d", len(findings), len(tt.wantTools))
+			}
+			for i, finding := range findings {
+				if finding.Tool != tt.wantTools[i] {
+					t.Errorf("finding %d tool = %q, want %q", i, finding.Tool, tt.wantTools[i])
+				}
+				if finding.Detail != tt.wantDetails[i] {
+					t.Errorf("finding %d detail = %q, want %q", i, finding.Detail, tt.wantDetails[i])
+				}
+			}
+		})
+	}
+}

--- a/detection/detection.go
+++ b/detection/detection.go
@@ -64,11 +64,16 @@ type Detector interface {
 // it cares about and ignores the rest.
 type Input struct {
 	CommitHash    string
-	CommitEmail   string
+	AuthorEmail   string
+	CommitEmail   string // CommitEmail is the committer email.
 	CommitMessage string
 	Notes         string // Content from refs/notes/ai, if any
 	Text          string // For text-only scans (PR body, comments)
 	RepoPath      string
+}
+
+func (input *Input) GetAuthorEmail() (string, error) {
+	return getCommitField(input.AuthorEmail, fieldAuthorEmail)
 }
 
 func (input *Input) GetCommitEmail() (string, error) {

--- a/detection/parsing.go
+++ b/detection/parsing.go
@@ -27,6 +27,7 @@ type agentID struct {
 }
 
 var (
+	fieldAuthorEmail   = "author_email"
 	fieldCommitEmail   = "commit_email"
 	fieldCommitMessage = "commit_message"
 )
@@ -39,7 +40,7 @@ func getCommitField(value string, field string) (string, error) {
 	}
 
 	switch field {
-	case fieldCommitEmail:
+	case fieldAuthorEmail, fieldCommitEmail:
 		return strings.ToLower(value), nil
 
 	case fieldCommitMessage:

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -64,6 +64,7 @@ func ScanText(text string, detectors []detection.Detector) []detection.Finding {
 func scanOneCommit(c gitops.Commit, detectors []detection.Detector) CommitResult {
 	input := detection.Input{
 		CommitHash:    c.Hash,
+		AuthorEmail:   c.AuthorEmail,
 		CommitEmail:   c.CommitterEmail,
 		CommitMessage: c.Message,
 		Notes:         c.Notes,

--- a/scan/scan_test.go
+++ b/scan/scan_test.go
@@ -64,7 +64,7 @@ Assisted-by: Gemini (documentation)
 			humanEmail,
 		},
 		{
-			"agent-authored change",
+			"agent-authored change\n\nAssisted-By: Kimi K2.6",
 			"198982749+copilot@users.noreply.github.com",
 			humanEmail,
 		},
@@ -157,23 +157,32 @@ func TestScanCommitRangeAll(t *testing.T) {
 	}
 }
 
-func TestScanCommitDetectsAuthorIdentity(t *testing.T) {
+func TestScanCommitDetectsAcrossDetectors(t *testing.T) {
 	dir, hashes := initTestRepo(t)
 
-	result, err := ScanCommit(dir, hashes[4], []detection.Detector{&committer.Detector{}})
+	result, err := ScanCommit(dir, hashes[4], allDetectors())
 	if err != nil {
 		t.Fatalf("ScanCommit: %v", err)
 	}
-	if len(result.Findings) != 1 {
-		t.Fatalf("got %d findings, want 1", len(result.Findings))
+
+	wantToolsByDetector := map[string]string{
+		(&committer.Detector{}).Name(): "GitHub Copilot (agent)",
+		(&trailer.Detector{}).Name():   "Kimi K2.6",
+	}
+	if len(result.Findings) != len(wantToolsByDetector) {
+		t.Fatalf("got %d findings, want %d", len(result.Findings), len(wantToolsByDetector))
 	}
 
-	finding := result.Findings[0]
-	if finding.Tool != "GitHub Copilot (agent)" {
-		t.Errorf("tool = %q, want %q", finding.Tool, "GitHub Copilot (agent)")
-	}
-	if finding.Detail != "author email 198982749+copilot@users.noreply.github.com matches known AI bot" {
-		t.Errorf("detail = %q, want author identity detail", finding.Detail)
+	for _, finding := range result.Findings {
+		wantTool, ok := wantToolsByDetector[finding.Detector]
+		if !ok {
+			t.Errorf("unexpected detector %q", finding.Detector)
+			continue
+		}
+		if finding.Tool != wantTool {
+			t.Errorf("%s tool = %q, want %q", finding.Detector, finding.Tool, wantTool)
+		}
+		delete(wantToolsByDetector, finding.Detector)
 	}
 }
 

--- a/scan/scan_test.go
+++ b/scan/scan_test.go
@@ -27,6 +27,8 @@ func allDetectors() []detection.Detector {
 
 func initTestRepo(t *testing.T) (string, []string) {
 	t.Helper()
+	const humanEmail = "human@example.com"
+
 	dir := t.TempDir()
 
 	repo, err := git.PlainInit(dir, false)
@@ -41,11 +43,12 @@ func initTestRepo(t *testing.T) (string, []string) {
 
 	commits := []struct {
 		msg            string
+		authorEmail    string
 		committerEmail string
 	}{
-		{"initial commit", "human@example.com"},
-		{"fix: update handler\n\nCo-Authored-By: Claude Opus 4 <noreply@anthropic.com>", "human@example.com"},
-		{"aider: refactor auth module", "human@example.com"},
+		{"initial commit", humanEmail, humanEmail},
+		{"fix: update handler\n\nCo-Authored-By: Claude Opus 4 <noreply@anthropic.com>", humanEmail, humanEmail},
+		{"aider: refactor auth module", humanEmail, humanEmail},
 		{`
 this is a commit message
 
@@ -57,7 +60,13 @@ Assisted-by: Kimi K2.6 (unit tests, integration tests)
 Assisted-by: ChatGPT (documentation review)
 Assisted-by: Gemini (documentation)
 `,
-			"human@example.com",
+			humanEmail,
+			humanEmail,
+		},
+		{
+			"agent-authored change",
+			"198982749+copilot@users.noreply.github.com",
+			humanEmail,
 		},
 	}
 
@@ -73,7 +82,7 @@ Assisted-by: Gemini (documentation)
 		hash, err := wt.Commit(c.msg, &git.CommitOptions{
 			Author: &object.Signature{
 				Name:  "Test",
-				Email: c.committerEmail,
+				Email: c.authorEmail,
 				When:  time.Now().Add(time.Duration(i) * time.Second),
 			},
 			Committer: &object.Signature{
@@ -143,8 +152,28 @@ func TestScanCommitRangeAll(t *testing.T) {
 		t.Fatalf("ScanCommitRange: %v", err)
 	}
 
-	if report.Summary.TotalCommits != 4 {
-		t.Errorf("total commits = %d, want 4", report.Summary.TotalCommits)
+	if report.Summary.TotalCommits != 5 {
+		t.Errorf("total commits = %d, want 5", report.Summary.TotalCommits)
+	}
+}
+
+func TestScanCommitDetectsAuthorIdentity(t *testing.T) {
+	dir, hashes := initTestRepo(t)
+
+	result, err := ScanCommit(dir, hashes[4], []detection.Detector{&committer.Detector{}})
+	if err != nil {
+		t.Fatalf("ScanCommit: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("got %d findings, want 1", len(result.Findings))
+	}
+
+	finding := result.Findings[0]
+	if finding.Tool != "GitHub Copilot (agent)" {
+		t.Errorf("tool = %q, want %q", finding.Tool, "GitHub Copilot (agent)")
+	}
+	if finding.Detail != "author email 198982749+copilot@users.noreply.github.com matches known AI bot" {
+		t.Errorf("detail = %q, want author identity detail", finding.Detail)
 	}
 }
 


### PR DESCRIPTION
Pass the Git author email into detection and check both author and committer identities against the existing agent map. This covers agent-authored commits where GitHub or a human records the commit.

`CommitEmail` remains the committer field for compatibility. Identical author and committer identities produce one finding, while different matching identities produce separate findings with the matched field in `Detail`.