### PR TITLE
Normalize Assisted-By tool names

### DIFF
--- a/detection/trailer/trailer.go
+++ b/detection/trailer/trailer.go
@@ -22,7 +22,12 @@ func extractToolFromText(text string) (string, error) {
 	// trimming any values in brackets e.g. Claude (Anthropic)
 	text, _, _ = strings.Cut(text, "(")
 
-	text = strings.TrimSpace(text)
+	text = strings.Join(strings.Fields(text), " ")
+	text = strings.TrimSpace(strings.TrimRight(text, ".,;:!?"))
+	if len(text) >= 2 && strings.HasPrefix(text, "[") && strings.HasSuffix(text, "]") {
+		text = strings.TrimSpace(text[1 : len(text)-1])
+		text = strings.TrimSpace(strings.TrimRight(text, ".,;:!?"))
+	}
 	if text == "" {
 		return "", fmt.Errorf("no contents found in text")
 	}
@@ -186,7 +191,11 @@ func (d *Detector) detectTrailerAssistedBy(commitMessage string) []detection.Fin
 		}
 
 		matchedTool, err := extractToolFromText(match[1])
-		if err != nil || seen[matchedTool] {
+		if err != nil {
+			continue
+		}
+		matchedToolKey := cases.Fold().String(matchedTool)
+		if seen[matchedToolKey] {
 			continue
 		}
 
@@ -196,7 +205,7 @@ func (d *Detector) detectTrailerAssistedBy(commitMessage string) []detection.Fin
 			Confidence: detection.ConfidenceHigh,
 			Detail:     fmt.Sprintf("Assisted-By trailer with tool %s", matchedTool),
 		})
-		seen[matchedTool] = true
+		seen[matchedToolKey] = true
 	}
 	return findings
 }

--- a/detection/trailer/trailer_test.go
+++ b/detection/trailer/trailer_test.go
@@ -234,6 +234,36 @@ Signed-off-by: some human <test@example.com>
 			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
 		},
 		{
+			name:           "assistedby: Equivalent tools are deduplicated across multiple trailers",
+			message:        "this is a commit message with\nAssisted-By: Claude Code\nAssisted-By: CLAUDE CODE\nAssisted-By: [Claude   Code].\nAssisted-By: GitHub Copilot",
+			wantTools:      []string{"Claude Code", "GitHub Copilot"},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh, detection.ConfidenceHigh},
+		},
+		{
+			name:           "assistedby: Tool with enclosing square brackets",
+			message:        "this is a commit message with\nAssisted-By: [Claude Code]",
+			wantTools:      []string{"Claude Code"},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
+			name:           "assistedby: Tool with extra whitespace and terminal punctuation",
+			message:        "this is a commit message with\nAssisted-By: Claude   Code.",
+			wantTools:      []string{"Claude Code"},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
+			name:           "assistedby: Internal model punctuation is preserved",
+			message:        "this is a commit message with\nAssisted-By: GPT-5.5",
+			wantTools:      []string{"GPT-5.5"},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
+			name:           "assistedby: Internal tool punctuation is preserved",
+			message:        "this is a commit message with\nAssisted-By: Continue.dev",
+			wantTools:      []string{"Continue.dev"},
+			wantConfidence: []detection.Confidence{detection.ConfidenceHigh},
+		},
+		{
 			name:           "assistedby: Assisted-By trailer in commit message in lower case",
 			message:        "this is a commit message with\nassisted-by: Claude Code",
 			wantTools:      []string{"Claude Code"},


### PR DESCRIPTION
`Assisted-By` values are free-form, so small formatting differences currently produce separate tool names. This normalizes internal whitespace, enclosing square brackets, and terminal sentence punctuation, then deduplicates equivalent values case-insensitively while preserving the first spelling.

It leaves versions and internal punctuation untouched, so values such as `GPT-5.5` and `Continue.dev` remain intact. The regression coverage includes multiple `Assisted-By` trailers and keeps distinct tools as separate findings.