### PR TITLE
docs: add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ action/                 GitHub Action (composite action + labeling)
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## License
 
-Code is licensed under [GNU General Public License v3.0](https://github.com/chaoss/disclosure/blob/main/LICENSE).
+Code is licensed under [GNU General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -180,3 +180,6 @@ action/                 GitHub Action (composite action + labeling)
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+## License
+
+Code is licensed under [GNU General Public License v3.0](https://github.com/chaoss/disclosure/blob/main/LICENSE).


### PR DESCRIPTION
Fixes #70

Adds a short License section at the end of the README linking to the
GPLv3 LICENSE file, per the maintainer's suggested wording in the issue.

AI disclosure: drafted with AI assistance (Claude) for wording and
git workflow steps; the change itself is a one-line documentation
addition that I reviewed and verified against the current README
before submitting.

Testing: documentation-only change, no build/test impact.