### PR TITLE
docs: add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ action/                 GitHub Action (composite action + labeling)
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+Code is licensed under [GNU General Public License v3.0](https://github.com/chaoss/disclosure/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
Adds a License section at the end of the README pointing at the existing GPLv3 LICENSE file, as requested in the issue.

Closes #70