### PR TITLE
Clean filepath, fix dir permissions, update crypto version, pin setup-go commit sha

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -10,6 +10,11 @@ inputs:
     description: 'Enable/disable labeling, requires PR and Issue write permissions when enabled'
     required: false
     default: 'false'
+    # Note: Setting labeling-enabled to true will need write permissions to pull requests and issues,
+    # so consider setting the following in your calling action:
+    # permissions:
+    #   pull-requests: write
+    #   issues: write
   min-confidence:
     description: 'Minimum confidence level (low, medium, high)'
     required: false
@@ -31,7 +36,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '1.25'
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -212,7 +212,7 @@ Examples:
 			if inputFlag == "-" {
 				textBytes, err = io.ReadAll(os.Stdin)
 			} else {
-				textBytes, err = os.ReadFile(inputFlag)
+				textBytes, err = os.ReadFile(filepath.Clean(inputFlag))
 			}
 			if err != nil {
 				fmt.Fprintf(stderr, "error reading input: %v\n", err)
@@ -347,7 +347,7 @@ func generateDocs(exitCode *int) *cobra.Command {
 			// create required dir for docs inside output dir
 			if slices.Contains(supportedFormats, formatFlag) {
 				docDir = filepath.Clean(filepath.Join(outputDir, formatFlag))
-				err = os.MkdirAll(docDir, 0o755)
+				err = os.MkdirAll(docDir, 0o750)
 			} else {
 				err = fmt.Errorf("unknown format: %s\n", formatFlag)
 			}

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
-golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -95,11 +95,11 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
-golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=


### PR DESCRIPTION
**Description**

This PR cleans file path before reading in `disclosure text` command, and also uses appropriate permissions (750) for docs dir. Additionally updates golang/x/crypto version to the latest one (v0.54.0) and pins setup-go version used in action to v7.0.0 commit sha.

**Notes for Reviewers**

**Signed commits**
- [x] Yes, I signed my commits.


**Generative AI disclosure**
<!-- To learn more about our Generative AI policy and required disclosures, see the `CONTRIBUTING.md` file -->

Please select one option:

- [x] This contribution was NOT assisted or created by Generative AI tools.
- [ ] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? <!-- gemini / chatgpt / claude .etc -->
    - How were these tools used? <!-- initial draft of the code / code review / writing tests .etc -->
    - Did you review these outputs before submitting this PR? <!-- No / Yes and I made these fixes... -->

<!--
Thank you for contributing to CHAOSS projects! 

Contributing Conventions:
1. Include descriptive PR titles
2. Build and test your changes before submitting a PR
3. Sign your commits

By following the community's [contribution conventions](https://github.com/chaoss/disclosure/blob/main/CONTRIBUTING.md) upfront, the review process will be accelerated and your PR merged more quickly.
-->
