### PR TITLE
Add zizmor pull request check

### DIFF
--- a/.github/workflows/ai_detection.yml
+++ b/.github/workflows/ai_detection.yml
@@ -24,5 +24,6 @@ jobs:
       with:
         # we get commit history from base as its needed by the AI detection action
         fetch-depth: 0
+        persist-credentials: false
     - name: Run AI detection action
       uses: ./action

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions security scan
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
+        with:
+          advanced-security: false
+          annotations: true
+          config: .github/zizmor.yml

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions security scan
+name: GitHub Actions static analysis
 
 on:
   pull_request:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin


### PR DESCRIPTION
**Description**
- Add a zizmor pull request check for GitHub Actions workflows and composite actions.
- Require SHA-pinned action references through a checked-in zizmor policy.
- Disable persisted checkout credentials in the existing AI detection workflow.

This PR does not fix a linked issue.

**Notes for Reviewers**

The zizmor action is SHA-pinned and runs with annotations without requiring GitHub Advanced Security. The setup follows the [zizmor action documentation](https://github.com/zizmorcore/zizmor-action) and [zizmor configuration documentation](https://docs.zizmor.sh/configuration/).

**Signed commits**
- [x] Yes, I signed my commits.


**Generative AI disclosure**

Please select one option:

- [ ] This contribution was NOT assisted or created by Generative AI tools.
- [x] This contribution was assisted or created by Generative AI tools.


If AI tools were used, please provide details below:
    - What tools were used? OpenAI Codex.
    - How were these tools used? Codex was used to inspect the existing configuration, draft the workflow and policy, run validation, and prepare this PR.
    - Did you review these outputs before submitting this PR? Yes. I reviewed the changes and the local validation output before submitting.
